### PR TITLE
fix: Remove foreign key constraint from related_key

### DIFF
--- a/backend/api/db/AIResponse.py
+++ b/backend/api/db/AIResponse.py
@@ -10,4 +10,4 @@ class AiResponse(SQLModel, table=True):
     sentiment_prediction: str
     consulted_query_date: datetime.datetime = Field(index=True)
     user_id: uuid.UUID
-    related_key:str|None = Field(default=None, foreign_key="airesponsetags.related_key")
+    related_key:str|None = Field(default=None)


### PR DESCRIPTION
## Description
Quick fix related to Foreign Key that by the logic it is not needed and was raising some errors


- Old
```python
class AiResponse(SQLModel, table=True):
    id: int | None = Field(primary_key=True, default=None)
    text: str
    sentiment_prediction: str
    consulted_query_date: datetime.datetime = Field(index=True)
    user_id: uuid.UUID
    related_key:str|None = Field(default=None, foreign_key="airesponsetags.related_key")
```
- New
```python
class AiResponse(SQLModel, table=True):
    id: int | None = Field(primary_key=True, default=None)
    text: str
    sentiment_prediction: str
    consulted_query_date: datetime.datetime = Field(index=True)
    user_id: uuid.UUID
    related_key:str|None = Field(default=None)
```